### PR TITLE
Improve speed of loading

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -289,7 +289,7 @@ export function buildShellPOVExe(settings: any, fileInfo: any, outFilePath: any,
     if (context.platform === 'win32' && !context.isWindowsBash) {
 
         // Change the povray executable to the windows pvengine instead
-        exe = "pvengine /EXIT /RENDER";
+        exe = "pvengine /EXIT /RENDER /nr";
     }
 
     // If we are running povray via Docker


### PR DESCRIPTION
The /nr command line option prevents restoring old files in the editor and improves the performance of loading.